### PR TITLE
Add new header for *uv*.

### DIFF
--- a/colorconverter.py
+++ b/colorconverter.py
@@ -1,3 +1,10 @@
+# /// script
+# dependencies = [
+#     "colour-science",
+#     "matplotlib",
+# ]
+# ///
+
 """
 Color Converter
 ===============


### PR DESCRIPTION
Allows to use the `colorconverter` without using any dependencies but [uv](https://docs.astral.sh/uv/getting-started/installation/):

`uv run https://raw.githubusercontent.com/KelSolaar/colorconverter/refs/heads/main/colorconverter.py`

Ideally, there would be a `pyproject.toml` file so that it is also possible to do `uvx --from git+https://raw.githubusercontent.com/KelSolaar/colorconverter colorconverter`